### PR TITLE
Fix: utility tab now follows tab logic

### DIFF
--- a/src/nomm/gui/dashboard.py
+++ b/src/nomm/gui/dashboard.py
@@ -147,6 +147,8 @@ class GameDashboard(Gtk.Box):
 
         # Grouping
         self.dl_tab_btn.set_group(self.mods_tab_btn)
+        if game_info.get("utilities"):
+            self.tools_tab_btn.set_group(self.mods_tab_btn)
         self.mods_tab_btn.set_active(True)
 
         # Banner


### PR DESCRIPTION
Utility tab button was not added to the dashboard header tab group, which meant it was treated as a separate button from the other two tabs.
This is now fixed.