### PR TITLE
Hotfix: nexus downloads broken

### DIFF
--- a/build/flatpak/moe.nomm.Nomm.metainfo.xml
+++ b/build/flatpak/moe.nomm.Nomm.metainfo.xml
@@ -40,6 +40,15 @@
       <description>
         <p>Release bites</p>
         <ul>
+          <li>Fix a regression impacting Nexus one-click downloads</li>
+        </ul>
+      </description>
+      <url>https://github.com/nomm-team/nomm-app/releases/0.13.3</url>
+    </release>
+    <release type="stable" version="0.13.3" date="2026-09-07T00:00:00Z">
+      <description>
+        <p>Release bites</p>
+        <ul>
           <li>1-click download enabled for GameBanana on Mario Kart 8 Deluxe mods!</li>
           <li>Fixed incorrect link on submitter button for GameBanana mods</li>
           <li>Fixed some UI strings with incorrect spacing</li>
@@ -91,15 +100,6 @@
         </ul>
       </description>
       <url>https://github.com/nomm-team/nomm-app/releases/0.12.6</url>
-    </release>
-    <release type="stable" version="0.12.5" date="2026-08-24T00:00:00Z">
-      <description>
-        <p>Release bites</p>
-        <ul>
-          <li>Fixed regression stopping utilities from being correctly downloaded</li>
-        </ul>
-      </description>
-      <url>https://github.com/nomm-team/nomm-app/releases/0.12.5</url>
     </release>
   </releases>
   <content_rating type="oars-1.1">

--- a/release_bites.yaml
+++ b/release_bites.yaml
@@ -4,6 +4,13 @@ Date: 2026-09-07
 URL: https://github.com/nomm-team/nomm-app/releases/0.13.3
 Description: |-
   Release bites
+   * Fix a regression impacting Nexus one-click downloads
+---
+Version: "0.13.3"
+Date: 2026-09-07
+URL: https://github.com/nomm-team/nomm-app/releases/0.13.3
+Description: |-
+  Release bites
    * 1-click download enabled for GameBanana on Mario Kart 8 Deluxe mods!
    * Fixed incorrect link on submitter button for GameBanana mods
    * Fixed some UI strings with incorrect spacing

--- a/src/nomm/core/user_config.py
+++ b/src/nomm/core/user_config.py
@@ -1,6 +1,6 @@
 import os
 import gettext
-
+from pathlib import Path
 from gi.repository import GLib
 from nomm.core.tools import load_yaml, write_yaml
 from typing import List, Dict, Any
@@ -10,6 +10,7 @@ _ = gettext.gettext
 
 if ".local" in GLib.get_user_data_dir():  # local installation i.e. running python
     DATA_DIR = os.path.join(GLib.get_user_data_dir(), "nomm")
+    Path(DATA_DIR).mkdir(parents=True, exist_ok=True)
 else:  # a flatpak, no need to add "nomm" parent folder
     DATA_DIR = os.path.join(GLib.get_user_data_dir())
 

--- a/src/nomm/core/user_config.py
+++ b/src/nomm/core/user_config.py
@@ -72,3 +72,15 @@ def parse_mod_paths(deployment_dicts: list | str, game_path: str, user_data_path
         deployment_dict["path"] = deployment_path
 
     return deployment_dicts
+
+
+def get_game_config(nexus_id=None):
+    for config_path in [CUSTOM_GAME_CONFIG_PATH, PRESET_GAME_CONFIG_PATH]:
+        if os.path.exists(config_path):
+            for filename in os.listdir(config_path):
+                if filename.lower().endswith((".yaml", ".yml")):
+                    game_config = load_yaml(os.path.join(config_path, filename))
+                    # If we ever need to add more platforms we can do it here easily
+                    if nexus_id and game_config.get("nexus_id") == nexus_id:
+                        return game_config
+    return None

--- a/src/nomm/gui/application.py
+++ b/src/nomm/gui/application.py
@@ -147,10 +147,7 @@ class Nomm(Adw.Application):
 
     def _process_link(self, uri, handler_fn):
         started = False
-        try:
-            started = handler_fn(uri, self.downloader, self.headers)
-        except Exception as e:
-            print(f"Error handling URI {uri}: {e}")
+        started = handler_fn(uri, self.downloader, self.headers)
 
         callback = (
             self._connect_release_on_finish if started else self.release

--- a/src/nomm/gui/dashboard_views/mods_tab.py
+++ b/src/nomm/gui/dashboard_views/mods_tab.py
@@ -1038,7 +1038,7 @@ class ModsTab(Gtk.Box):
     def check_for_mod_updates_async(self, staging_metadata: dict, download_dir: Path, on_complete_callback: Optional[Callable]) -> None:
         def worker():
             print("Checking for updates in background...")
-            nexus_id = staging_metadata.get("info").get("nexus_id")
+            nexus_id = self.dashboard.game_info["nexus_id"]
             for mod_name, mod_metadata in staging_metadata.get("mods", {}).items():
                 mod_id = mod_metadata.get("mod_id")
                 local_version = str(mod_metadata.get("version", ""))

--- a/src/nomm/platforms/nexus.py
+++ b/src/nomm/platforms/nexus.py
@@ -337,6 +337,7 @@ def _fetch_and_write_mod_metadata(nxm_link: str, headers: dict, final_download_d
 
     mod_id = nxm_path[2]
     file_id = nxm_path[4]
+
     try:
         info_api_url = f"https://api.nexusmods.com/v1/games/{nexus_id}/mods/{mod_id}/files/{file_id}.json"
         info_response = requests.get(info_api_url, headers=headers)
@@ -352,7 +353,7 @@ def _fetch_and_write_mod_metadata(nxm_link: str, headers: dict, final_download_d
             downloader._active_downloads.discard(file_name)
         GLib.idle_add(downloader.emit, 'download-error', error_data)
         return
-
+    """
     mod_metadata = {
         "name": file_info_data.get("name", "Unknown Mod"),
         "version": file_info_data.get("version", "1.0"),
@@ -360,20 +361,11 @@ def _fetch_and_write_mod_metadata(nxm_link: str, headers: dict, final_download_d
         "mod_id": mod_id,
         "file_id": file_id,
         "mod_link": f"https://www.nexusmods.com/{nexus_id}/mods/{mod_id}"
-    }
+    }"""
 
     downloads_metadata_path = get_metadata_path(str(final_download_dir), is_staging=False)
     with meta_lock:
         downloads_metadata = load_yaml(downloads_metadata_path)
-
-        if "mods" not in downloads_metadata:
-            downloads_metadata["mods"] = {}
-        downloads_metadata["info"] = {}
-        downloads_metadata["info"]["game"] = game_folder_name
-        downloads_metadata["info"]["nexus_id"] = nexus_id
-        downloads_metadata["mods"][file_name] = mod_metadata
-
-        write_yaml(downloads_metadata, downloads_metadata_path)
 
     with downloader._downloads_lock:
         downloader._active_downloads.discard(file_name)
@@ -393,7 +385,8 @@ def _fetch_and_write_mod_metadata(nxm_link: str, headers: dict, final_download_d
     # Handle saving all of this data
     downloads_metadata_path = get_metadata_path(str(final_download_dir), is_staging=False)
     downloads_metadata = load_yaml(downloads_metadata_path)
-
+    if not downloads_metadata:
+        downloads_metadata = {}
     if "mods" not in downloads_metadata:
         downloads_metadata["mods"] = {}
     downloads_metadata["info"] = {}

--- a/src/nomm/platforms/nexus.py
+++ b/src/nomm/platforms/nexus.py
@@ -12,7 +12,7 @@ from nomm.core.mod_manager import get_metadata_path, meta_lock
 from nomm.core.downloader import Downloader
 from nomm.gui.notifications import download_popup, send_download_notification
 from nomm.core.tools import load_yaml, write_yaml, download_image, process_bbcode
-from nomm.core.user_config import get_game_config
+from nomm.core.user_config import get_game_config, load_user_config
 
 
 def endorse_nexus_mod(headers: dict, game_domain: str, mod_id: str, unendorse: bool):
@@ -112,10 +112,7 @@ def get_nexus_changelog(headers: dict, game_id: str, mod_id: str, remote_version
 
 # Interprets nxm links and launchs notification
 def handle_nexus_link(nxm_link: str, downloader: Downloader, headers: dict) -> bool:
-
-    app_dir = os.path.join(GLib.get_user_data_dir(), "nomm")
-    user_config_dir = os.path.join(app_dir, "user_config.yaml")
-    user_config = load_yaml(user_config_dir)
+    user_config = load_user_config()
     api_key = user_config.get("nexus_api_key")
     base_download_path = user_config.get("download_path")
 
@@ -148,11 +145,11 @@ def handle_nexus_link(nxm_link: str, downloader: Downloader, headers: dict) -> b
         return _download_nexus_collection(nxm_link, nexus_headers, final_download_dir, downloader)
     else:
         print("Downloading single mod")
-        return _download_nexus_mod(nxm_link, nexus_headers, final_download_dir, nexus_id, game_folder_name, user_config_dir, downloader)
+        return _download_nexus_mod(nxm_link, nexus_headers, final_download_dir, nexus_id, game_folder_name, downloader)
 
 
 def _download_nexus_mod(nxm_link: str, headers: dict, final_download_dir: Path, nexus_id: str,
-                        game_folder_name: str, user_config_dir, downloader: Downloader) -> bool:
+                        game_folder_name: str, downloader: Downloader) -> bool:
 
     splitted_nxm = urlsplit(nxm_link)
     nxm_path = splitted_nxm.path.split('/')
@@ -193,7 +190,7 @@ def _download_nexus_mod(nxm_link: str, headers: dict, final_download_dir: Path, 
         file_name = file_url.split('/')[-1].split('?')[0] or "download"
 
     print(f"Downloading {file_name} to {game_folder_name}...")
-    user_meta = load_yaml(user_config_dir)
+    user_meta = load_user_config()
     if user_meta.get('disable_download_window'):
         threading.Thread(
             target=downloader.download_mod,

--- a/src/nomm/platforms/nexus.py
+++ b/src/nomm/platforms/nexus.py
@@ -6,13 +6,13 @@ from urllib.parse import urlsplit, urlunsplit
 from urllib.error import HTTPError
 
 import requests
-import yaml
 from gi.repository import GLib
 
 from nomm.core.mod_manager import get_metadata_path, meta_lock
 from nomm.core.downloader import Downloader
 from nomm.gui.notifications import download_popup, send_download_notification
 from nomm.core.tools import load_yaml, write_yaml, download_image, process_bbcode
+from nomm.core.user_config import get_game_config
 
 
 def endorse_nexus_mod(headers: dict, game_domain: str, mod_id: str, unendorse: bool):
@@ -131,25 +131,14 @@ def handle_nexus_link(nxm_link: str, downloader: Downloader, headers: dict) -> b
     nexus_id = splitted_nxm.netloc.lower()
     print(f"Nexus Game ID: {nexus_id}")
 
-    game_configs_dir = os.path.join(app_dir, "game_configs")
-    game_folder_name = ""
+    game_config = get_game_config(nexus_id=nexus_id)
 
-    if os.path.exists(game_configs_dir):
-        for filename in os.listdir(game_configs_dir):
-            if filename.lower().endswith((".yaml", ".yml")):
-                try:
-                    with open(os.path.join(game_configs_dir, filename), 'r') as f:
-                        g_data = yaml.safe_load(f)
-                        if g_data and g_data.get("nexus_id") == nexus_id:
-                            game_folder_name = g_data.get("name", nexus_id)
-                            break
-                except FileNotFoundError:
-                    continue
-
-    if not game_folder_name:
+    if not game_config:
         print(f"Game {nexus_id} could not be found in game_configs!")
-        GLib.idle_add(send_download_notification, "failure-game-not-found", file_name=None, game_name=nexus_id, icon_path=None)
+        GLib.idle_add(send_download_notification, "failure-game-not-found", None, nexus_id, None)
         return False
+
+    game_folder_name = game_config.get("name")
 
     final_download_dir = Path(base_download_path) / game_folder_name
     final_download_dir.mkdir(parents=True, exist_ok=True)

--- a/src/nomm/platforms/nexus.py
+++ b/src/nomm/platforms/nexus.py
@@ -353,15 +353,6 @@ def _fetch_and_write_mod_metadata(nxm_link: str, headers: dict, final_download_d
             downloader._active_downloads.discard(file_name)
         GLib.idle_add(downloader.emit, 'download-error', error_data)
         return
-    """
-    mod_metadata = {
-        "name": file_info_data.get("name", "Unknown Mod"),
-        "version": file_info_data.get("version", "1.0"),
-        "changelog": file_info_data.get("changelog_html", ""),
-        "mod_id": mod_id,
-        "file_id": file_id,
-        "mod_link": f"https://www.nexusmods.com/{nexus_id}/mods/{mod_id}"
-    }"""
 
     downloads_metadata_path = get_metadata_path(str(final_download_dir), is_staging=False)
     with meta_lock:


### PR DESCRIPTION
- Fixed nexus downloads being broken for people who didn't have the old config format
- Fixed the notification pop up that was supposed to appear to tell you that NOMM couldn't find the config
- Fixed a separate issue where Nexus downloads wouldn't work when you didn't already have at least one previously downloaded mod
- Fixed the issue where metadata refresh didn't work when no mods were previously downloaded